### PR TITLE
fixed pull_output printing error

### DIFF
--- a/R/pipeline.R
+++ b/R/pipeline.R
@@ -132,6 +132,6 @@ pull_output.sewage_pipeline = function(x, component, ...) {
     stop("component must be a character string")
   }
   output = x$outputs[[component]]
-  print(output)
+  return(output)
 }
 


### PR DESCRIPTION
#19 
Fixes pull output to have a `return` rather than a `print` statement